### PR TITLE
Use formatted chip name for dual-OPL2 and others

### DIFF
--- a/examples/vgmrender/vgmrender.cpp
+++ b/examples/vgmrender/vgmrender.cpp
@@ -329,7 +329,7 @@ void add_chips(uint32_t clock, chip_type type, char const *chipname)
 	{
 		char name[100];
 		sprintf(name, "%s #%d", chipname, index);
-		active_chips.push_back(new vgm_chip<ChipType>(clockval, type, chipname));
+		active_chips.push_back(new vgm_chip<ChipType>(clockval, type, (numchips == 2) ? name : chipname));
 	}
 
 	if (type == CHIP_YM2608)


### PR DESCRIPTION
The name is formatted, but never used. This uses it if there is more than one chip.