### PR TITLE
Fix divide-by-zero if output contains just silence

### DIFF
--- a/examples/vgmrender/vgmrender.cpp
+++ b/examples/vgmrender/vgmrender.cpp
@@ -1120,6 +1120,11 @@ int write_wav(char const *filename, uint32_t output_rate, std::vector<int32_t> &
 		max_scale = std::max(max_scale, absval);
 	}
 
+	if (max_scale == 0) {
+		fprintf(stderr, "The WAV file data will only contain silence.\n");
+		max_scale = 1;
+	}
+
 	// now convert
 	std::vector<int16_t> wav_buffer(wav_buffer_src.size());
 	for (int index = 0; index < wav_buffer_src.size(); index++)


### PR DESCRIPTION
Of course it doesn't make too much sense, and most VGM files should contain some audio. I did run into this crash (divide by zero), so better warn and avoid the error than outright crash.