### PR TITLE
opm: initialize m_lfo_waveform to avoid UB

### DIFF
--- a/src/ymfm_opm.cpp
+++ b/src/ymfm_opm.cpp
@@ -74,6 +74,7 @@ opm_registers::opm_registers() :
 		m_lfo_waveform[2][index] = am | (pm << 8);
 
 		// waveform 3 is noise; it is filled in dynamically
+		m_lfo_waveform[3][index] = 0;
 	}
 }
 


### PR DESCRIPTION
Hello Aaron! We discovered this as part of an internal test suite for the DefleMask project.

We were seeing nondeterministic behaviour when rendering a demosong that used the YM2151. This patch fixes it.

Not sure if initializing this to 0 is a good idea, or would be better to initialize the waveform to some kind of (seeded?) noise.