### PR TITLE
The output could be negative, so better not to bit-shift it.

### DIFF
--- a/src/ymfm_opl.cpp
+++ b/src/ymfm_opl.cpp
@@ -2035,8 +2035,8 @@ void opll_base::generate(output_data *output, uint32_t numsamples)
 
 		// final output is multiplexed; we don't simulate that here except
 		// to average over everything
-		output->data[0] = (output->data[0] << 7) / 9;
-		output->data[1] = (output->data[1] << 7) / 9;
+		output->data[0] = (output->data[0] * 128) / 9;
+		output->data[1] = (output->data[1] * 128) / 9;
 	}
 }
 

--- a/src/ymfm_opn.cpp
+++ b/src/ymfm_opn.cpp
@@ -2398,8 +2398,8 @@ void ym2612::generate(output_data *output, uint32_t numsamples)
 		// a better sound mixer than we usually have, so just average over the six
 		// channels; also apply a 64/65 factor to account for the discontinuity
 		// adjustment above
-		output->data[0] = (output->data[0] << 7) * 64 / (6 * 65);
-		output->data[1] = (output->data[1] << 7) * 64 / (6 * 65);
+		output->data[0] = (output->data[0] * 128) * 64 / (6 * 65);
+		output->data[1] = (output->data[1] * 128) * 64 / (6 * 65);
 	}
 }
 
@@ -2432,8 +2432,8 @@ void ym3438::generate(output_data *output, uint32_t numsamples)
 
 		// YM3438 doesn't have the same DAC discontinuity, though its output is
 		// multiplexed like the YM2612
-		output->data[0] = (output->data[0] << 7) / 6;
-		output->data[1] = (output->data[1] << 7) / 6;
+		output->data[0] = (output->data[0] * 128) / 6;
+		output->data[1] = (output->data[1] * 128) / 6;
 	}
 }
 


### PR DESCRIPTION
When running with [UndefinedBehaviorSanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html), we've got some messages like this one:
runtime error: left shift of negative value -38
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /src/ymfm_opl.cpp:1695:38 in

This commit fixed the issue.