### PR TITLE
OPN: fixed behavior of F-Num2(registers 0xa4,0xac)

### DIFF
--- a/src/ymfm_opn.cpp
+++ b/src/ymfm_opn.cpp
@@ -146,7 +146,10 @@ bool opn_registers_base<IsOpnA>::write(uint16_t index, uint8_t data, uint32_t &c
 	// borrow unused registers 0xb8-bf/0x1b8-bf as temporary holding locations
 	if ((index & 0xf0) == 0xa0)
 	{
-		uint32_t latchindex = 0xb8 | (bitfield(index, 3) << 2) | bitfield(index, 0, 2);
+		if (bitfield(index, 0, 2) == 3)
+			return false;
+
+		uint32_t latchindex = 0xb8 | bitfield(index, 3);
 		if (IsOpnA)
 			latchindex |= index & 0x100;
 
@@ -157,9 +160,16 @@ bool opn_registers_base<IsOpnA>::write(uint16_t index, uint8_t data, uint32_t &c
 		// writes to the lower half only commit if the latch is there
 		else if (bitfield(m_regdata[latchindex], 7))
 		{
+			m_regdata[index] = data;
 			m_regdata[index | 4] = m_regdata[latchindex] & 0x3f;
 			m_regdata[latchindex] = 0;
 		}
+		return false;
+	}
+	else if ((index & 0xf8) == 0xb8)
+	{
+		// registers 0xb8-0xbf are used internally
+		return false;
 	}
 
 	// everything else is normal


### PR DESCRIPTION
This patch fixes the behavior of registers A4-A6h and AC-AEh in OPN.
In real chip, there is one latch for each of A4-A6h and AC-AEh.

In some games, if this behavior is not reproduced, a bug in the sound driver causes incorrect pitch.

Although this patch is little bit redundant, it uses  unused registers for latching as same as the original implementation.
Please modify, if you have better idea.