### PR TITLE
SSG: fixed output when both tone & noise are disabled

### DIFF
--- a/src/ymfm_ssg.cpp
+++ b/src/ymfm_ssg.cpp
@@ -201,14 +201,14 @@ void ssg_engine::output(output_data &output)
 	for (int chan = 0; chan < 3; chan++)
 	{
 		// noise depends on the noise state, which is the LSB of m_noise_state
-		uint32_t noise_on = m_regs.ch_noise_enable(chan) & m_noise_state;
+		uint32_t noise_on = m_regs.ch_noise_enable_n(chan) | m_noise_state;
 
 		// tone depends on the current tone state
-		uint32_t tone_on = m_regs.ch_tone_enable(chan) & m_tone_state[chan];
+		uint32_t tone_on = m_regs.ch_tone_enable_n(chan) | m_tone_state[chan];
 
 		// if neither tone nor noise enabled, return 0
 		uint32_t volume;
-		if ((noise_on | tone_on) == 0)
+		if ((noise_on & tone_on) == 0)
 			volume = 0;
 
 		// if the envelope is enabled, use its amplitude

--- a/src/ymfm_ssg.h
+++ b/src/ymfm_ssg.h
@@ -130,8 +130,8 @@ public:
 	uint32_t io_b_data() const                          { return m_regdata[0x0f]; }
 
 	// per-channel registers
-	uint32_t ch_noise_enable(uint32_t choffs) const     { return bitfield(~m_regdata[0x07], 3 + choffs); }
-	uint32_t ch_tone_enable(uint32_t choffs) const      { return bitfield(~m_regdata[0x07], 0 + choffs); }
+	uint32_t ch_noise_enable_n(uint32_t choffs) const     { return bitfield(m_regdata[0x07], 3 + choffs); }
+	uint32_t ch_tone_enable_n(uint32_t choffs) const      { return bitfield(m_regdata[0x07], 0 + choffs); }
 	uint32_t ch_tone_period(uint32_t choffs) const      { return m_regdata[0x00 + 2 * choffs] | (bitfield(m_regdata[0x01 + 2 * choffs], 0, 4) << 8); }
 	uint32_t ch_envelope_enable(uint32_t choffs) const  { return bitfield(m_regdata[0x08 + choffs], 4); }
 	uint32_t ch_amplitude(uint32_t choffs) const        { return bitfield(m_regdata[0x08 + choffs], 0, 4); }


### PR DESCRIPTION
This is a patch to fix incorrect behavior of the mixer-control register in SSG.

ch_noise_enable_n()/ch_tone_enable_n() are not good names, but I couldn't have a better one.