### PR TITLE
ADPCM: fixed end/limit address checking and reading external data

### DIFF
--- a/src/ymfm_adpcm.cpp
+++ b/src/ymfm_adpcm.cpp
@@ -564,18 +564,27 @@ uint8_t adpcm_b_channel::read(uint32_t regnum)
 			m_dummy_read--;
 		}
 
-		// did we hit the end? if so, signal EOS
-		if (at_end())
-		{
-			m_status = STATUS_EOS | STATUS_BRDY;
-			debug::log_keyon("%s\n", "ADPCM EOS");
-		}
-
-		// otherwise, write the data and signal ready
+		// read the data
 		else
 		{
+			// read from outside of the chip
 			result = m_owner.intf().ymfm_external_read(ACCESS_ADPCM_B, m_curaddress++);
-			m_status = STATUS_BRDY;
+
+			// did we hit the end? if so, signal EOS
+			if (at_end())
+			{
+				m_status = STATUS_EOS | STATUS_BRDY;
+				debug::log_keyon("%s\n", "ADPCM EOS");
+			}
+			else
+			{
+				// signal ready
+				m_status = STATUS_BRDY;
+			}
+
+			// wrap at the limit address
+			if (at_limit())
+				m_curaddress = 0;
 		}
 	}
 	return result;

--- a/src/ymfm_adpcm.cpp
+++ b/src/ymfm_adpcm.cpp
@@ -462,10 +462,6 @@ void adpcm_b_channel::clock()
 	// if playing from RAM/ROM, check the end address and process
 	if (m_regs.external())
 	{
-		// wrap at the limit address
-		if (at_limit())
-			m_curaddress = 0;
-
 		// handle the sample end, either repeating or stopping
 		if (at_end())
 		{
@@ -483,6 +479,10 @@ void adpcm_b_channel::clock()
 				return;
 			}
 		}
+
+		// wrap at the limit address
+		if (at_limit())
+			m_curaddress = 0;
 
 		// if we're about to process nibble 0, fetch and increment
 		if (m_curnibble == 0)

--- a/src/ymfm_adpcm.h
+++ b/src/ymfm_adpcm.h
@@ -342,10 +342,10 @@ private:
 	void load_start();
 
 	// limit checker
-	bool at_limit() const { return (m_curaddress >> address_shift()) >= m_regs.limit(); }
+	bool at_limit() const { return m_curaddress == (((m_regs.limit() + 1) << address_shift()) - 1); }
 
 	// end checker
-	bool at_end() const { return (m_curaddress >> address_shift()) > m_regs.end(); }
+	bool at_end() const { return m_curaddress == (((m_regs.end() + 1) << address_shift()) - 1); }
 
 	// internal state
 	uint32_t const m_address_shift; // address bits shift-left

--- a/src/ymfm_adpcm.h
+++ b/src/ymfm_adpcm.h
@@ -342,17 +342,17 @@ private:
 	void load_start();
 
 	// limit checker
-	bool at_limit() const { return m_curaddress == (((m_regs.limit() + 1) << address_shift()) - 1); }
+	bool at_limit() const { return m_curaddress == (((m_regs.limit() + 1) << address_shift())); }
 
 	// end checker
-	bool at_end() const { return m_curaddress == (((m_regs.end() + 1) << address_shift()) - 1); }
+	bool at_end() const { return m_curaddress == (((m_regs.end() + 1) << address_shift())); }
 
 	// internal state
 	uint32_t const m_address_shift; // address bits shift-left
 	uint32_t m_status;              // currently playing?
 	uint32_t m_curnibble;           // index of the current nibble
 	uint32_t m_curbyte;             // current byte of data
-	uint32_t m_dummy_read;          // dummy read tracker
+	uint32_t m_read_buff;			// read buffer for external read
 	uint32_t m_position;            // current fractional position
 	uint32_t m_curaddress;          // current address
 	int32_t m_accumulator;          // accumulator

--- a/src/ymfm_opn.cpp
+++ b/src/ymfm_opn.cpp
@@ -1094,7 +1094,7 @@ uint8_t ym2608::read_status_hi()
 uint8_t ym2608::read_data_hi()
 {
 	uint8_t result = 0;
-	if (m_address < 0x10)
+	if ((m_address & 0xff) < 0x10)
 	{
 		// 00-0F: Read from ADPCM-B
 		result = m_adpcm_b.read(m_address & 0x0f);


### PR DESCRIPTION
This patch fixes checking of end and limit addresses in ADPCM.

In the original implementation, loop playback of ADPCM sound was sometimes incorrect because the limit address checking was done first and it changed the data address to 0.