### PR TITLE
ADPCM: fixed end/limit address checking

### DIFF
--- a/src/ymfm_adpcm.cpp
+++ b/src/ymfm_adpcm.cpp
@@ -462,10 +462,6 @@ void adpcm_b_channel::clock()
 	// if playing from RAM/ROM, check the end address and process
 	if (m_regs.external())
 	{
-		// wrap at the limit address
-		if (at_limit())
-			m_curaddress = 0;
-
 		// handle the sample end, either repeating or stopping
 		if (at_end())
 		{
@@ -483,6 +479,10 @@ void adpcm_b_channel::clock()
 				return;
 			}
 		}
+
+		// wrap at the limit address
+		if (at_limit())
+			m_curaddress = 0;
 
 		// if we're about to process nibble 0, fetch and increment
 		if (m_curnibble == 0)

--- a/src/ymfm_adpcm.cpp
+++ b/src/ymfm_adpcm.cpp
@@ -491,6 +491,7 @@ void adpcm_b_channel::clock()
 					m_prev_accum = 0;
 					m_status = (m_status & ~STATUS_PLAYING) | STATUS_EOS;
 					debug::log_keyon("%s\n", "ADPCM EOS");
+					return;
 				}
 			}
 

--- a/src/ymfm_adpcm.h
+++ b/src/ymfm_adpcm.h
@@ -342,10 +342,10 @@ private:
 	void load_start();
 
 	// limit checker
-	bool at_limit() const { return (m_curaddress >> address_shift()) >= m_regs.limit(); }
+	bool at_limit() const { return m_curaddress == (((m_regs.limit() + 1) << address_shift())); }
 
 	// end checker
-	bool at_end() const { return (m_curaddress >> address_shift()) > m_regs.end(); }
+	bool at_end() const { return m_curaddress == (((m_regs.end() + 1) << address_shift())); }
 
 	// internal state
 	uint32_t const m_address_shift; // address bits shift-left

--- a/src/ymfm_adpcm.h
+++ b/src/ymfm_adpcm.h
@@ -342,10 +342,10 @@ private:
 	void load_start();
 
 	// limit checker
-	bool at_limit() const { return m_curaddress == (((m_regs.limit() + 1) << address_shift())); }
+	bool at_limit() const { return m_curaddress == ((m_regs.limit() << address_shift()) | ((1 << address_shift()) - 1)); }
 
 	// end checker
-	bool at_end() const { return m_curaddress == (((m_regs.end() + 1) << address_shift())); }
+	bool at_end() const { return m_curaddress == ((m_regs.end() << address_shift()) | ((1 << address_shift()) - 1)); }
 
 	// internal state
 	uint32_t const m_address_shift; // address bits shift-left


### PR DESCRIPTION
It is a fixed patch I have sent in PR #31 first.
In the original behavior, ADPCM sounds doesn't play with loop if stop address and limit address are same.
I reffered the behavior and implementation of fmgen.

https://github.com/aaronsgiles/ymfm/pull/31#issue-1190632498

----

This patch fixes checking of end and limit addresses in ADPCM.

In the original implementation, loop playback of ADPCM sound was sometimes incorrect because the limit address checking was done first and it changed the data address to 0.
