### PR TITLE
OPNA: fixed reading ADPCM reg

### DIFF
--- a/src/ymfm_opn.cpp
+++ b/src/ymfm_opn.cpp
@@ -1104,7 +1104,7 @@ uint8_t ym2608::read_status_hi()
 uint8_t ym2608::read_data_hi()
 {
 	uint8_t result = 0;
-	if (m_address < 0x10)
+	if ((m_address & 0xff) < 0x10)
 	{
 		// 00-0F: Read from ADPCM-B
 		result = m_adpcm_b.read(m_address & 0x0f);


### PR DESCRIPTION
This patch is a part of fix I send in PR #31.

I splitted the following commit into 2 comits and it is for reading ADPCM register
[OPNA/ADPCM: fixed reading reg values and external data](https://github.com/aaronsgiles/ymfm/pull/31/commits/6339a8ae8b6edea35fb22dde6603cd4ae18adf9c)

In case of ADPCM register accessing, m_address is ORed with 0x100.
Should be masked for range check.

```
void ymf288::write_address_hi(uint8_t data)
{
	// just set the address
	m_address = 0x100 | data;
```

P.S.
For reading external data, I'll send with another PR.
