### PR TITLE
ADPCM: fixed reading external data

### DIFF
--- a/src/ymfm_adpcm.cpp
+++ b/src/ymfm_adpcm.cpp
@@ -564,18 +564,27 @@ uint8_t adpcm_b_channel::read(uint32_t regnum)
 			m_dummy_read--;
 		}
 
-		// did we hit the end? if so, signal EOS
-		if (at_end())
-		{
-			m_status = STATUS_EOS | STATUS_BRDY;
-			debug::log_keyon("%s\n", "ADPCM EOS");
-		}
-
-		// otherwise, write the data and signal ready
+		// read the data
 		else
 		{
+			// read from outside of the chip
 			result = m_owner.intf().ymfm_external_read(ACCESS_ADPCM_B, m_curaddress++);
-			m_status = STATUS_BRDY;
+
+			// did we hit the end? if so, signal EOS
+			if (at_end())
+			{
+				m_status = STATUS_EOS | STATUS_BRDY;
+				debug::log_keyon("%s\n", "ADPCM EOS");
+			}
+			else
+			{
+				// signal ready
+				m_status = STATUS_BRDY;
+			}
+
+			// wrap at the limit address
+			if (at_limit())
+				m_curaddress = 0;
 		}
 	}
 	return result;


### PR DESCRIPTION
This patch is a part of fix I send in PR https://github.com/aaronsgiles/ymfm/pull/31.

I splitted the following commit into 2 comits and it is for reading external ADPCM memory.
[OPNA/ADPCM: fixed reading reg values and external data](https://github.com/aaronsgiles/ymfm/pull/31/commits/6339a8ae8b6edea35fb22dde6603cd4ae18adf9c)

I think this fix is better than the original, but in some case, behavior of status ragister is still not good because of behavior of dummy read.
Change for dummy read in PR #31 depends on this PR and I need to consider how to share with you.
