### PR TITLE
ADPCM: fixed address checking on read/write

### DIFF
--- a/src/ymfm_adpcm.cpp
+++ b/src/ymfm_adpcm.cpp
@@ -580,23 +580,31 @@ uint8_t adpcm_b_channel::read(uint32_t regnum)
 		else
 		{
 			// read from outside of the chip
-			result = m_owner.intf().ymfm_external_read(ACCESS_ADPCM_B, m_curaddress++);
+			result = m_owner.intf().ymfm_external_read(ACCESS_ADPCM_B, m_curaddress);
 
 			// did we hit the end? if so, signal EOS
 			if (at_end())
 			{
+				m_dummy_read = 2;
 				m_status = STATUS_EOS | STATUS_BRDY;
 				debug::log_keyon("%s\n", "ADPCM EOS");
 			}
 			else
 			{
+				// wrap at the limit address
+				if (at_limit())
+					m_curaddress = 0;
+
+				// advance the current address
+				else
+				{
+					m_curaddress++;
+					m_curaddress &= 0xffffff;
+				}
+
 				// signal ready
 				m_status = STATUS_BRDY;
 			}
-
-			// wrap at the limit address
-			if (at_limit())
-				m_curaddress = 0;
 		}
 	}
 	return result;
@@ -661,17 +669,30 @@ void adpcm_b_channel::write(uint32_t regnum, uint8_t value)
 				m_dummy_read = 0;
 			}
 
+			// write the data and signal ready
+			m_owner.intf().ymfm_external_write(ACCESS_ADPCM_B, m_curaddress, value);
+
 			// did we hit the end? if so, signal EOS
 			if (at_end())
 			{
-				debug::log_keyon("%s\n", "ADPCM EOS");
+				m_dummy_read = 2;
 				m_status = STATUS_EOS | STATUS_BRDY;
+				debug::log_keyon("%s\n", "ADPCM EOS");
 			}
-
-			// otherwise, write the data and signal ready
 			else
 			{
-				m_owner.intf().ymfm_external_write(ACCESS_ADPCM_B, m_curaddress++, value);
+				// wrap at the limit address
+				if (at_limit())
+					m_curaddress = 0;
+
+				// advance the current address
+				else
+				{
+					m_curaddress++;
+					m_curaddress &= 0xffffff;
+				}
+
+				// signal ready
 				m_status = STATUS_BRDY;
 			}
 		}

--- a/src/ymfm_adpcm.h
+++ b/src/ymfm_adpcm.h
@@ -338,6 +338,9 @@ public:
 	// return the status register
 	uint8_t status() const { return m_status & STATUS_EXTERNAL; }
 
+	// clear bits in the status register
+	void clear_status(uint8_t status) { m_status &= ~(status & STATUS_EXTERNAL); }
+
 	// handle special register reads
 	uint8_t read(uint32_t regnum);
 
@@ -402,6 +405,7 @@ public:
 
 	// status
 	uint8_t status() const { return m_channel->status(); }
+	void clear_status(uint8_t status) { m_channel->clear_status(status); }
 
 	// return a reference to our interface
 	ymfm_interface &intf() { return m_intf; }

--- a/src/ymfm_adpcm.h
+++ b/src/ymfm_adpcm.h
@@ -300,19 +300,22 @@ private:
 
 class adpcm_b_channel
 {
-	friend class adpcm_tester;
-
 	static constexpr int32_t STEP_MIN = 127;
 	static constexpr int32_t STEP_MAX = 24576;
 
 public:
-	static constexpr uint8_t STATUS_EOS = 0x01;
-	static constexpr uint8_t STATUS_BRDY = 0x02;
-	static constexpr uint8_t STATUS_PLAYING = 0x04;
-	static constexpr uint8_t STATUS_EXTERNAL = STATUS_EOS | STATUS_BRDY | STATUS_PLAYING;
+	// publicly visible status bits
+	static constexpr uint32_t STATUS_EOS = 0x01;
+	static constexpr uint32_t STATUS_BRDY = 0x02;
+	static constexpr uint32_t STATUS_PLAYING = 0x04;
 
-	static constexpr uint8_t STATUS_INTERNAL_DRAIN = 0x08;
+private:
+	// internal status bits
+	static constexpr uint32_t STATUS_EXTERNAL = STATUS_EOS | STATUS_BRDY | STATUS_PLAYING;
+	static constexpr uint32_t STATUS_INTERNAL_DRAIN = 0x08;
+	static constexpr uint32_t STATUS_INTERNAL_PLAYING = 0x10;
 
+public:
 	// constructor
 	adpcm_b_channel(adpcm_b_engine &owner, uint32_t addrshift);
 
@@ -343,7 +346,7 @@ public:
 
 private:
 	// update the status register
-	void set_reset_status(uint8_t set, uint8_t reset = 0) { m_status = (m_status & ~reset) | set; }
+	void set_reset_status(uint32_t set, uint32_t reset = 0) { m_status = (m_status & ~reset) | set; }
 
 	// return the current address shift
 	uint32_t address_shift() const;
@@ -374,8 +377,6 @@ private:
 
 class adpcm_b_engine
 {
-	friend class adpcm_tester;
-
 public:
 	// constructor
 	adpcm_b_engine(ymfm_interface &intf, uint32_t addrshift = 0);

--- a/src/ymfm_opl.cpp
+++ b/src/ymfm_opl.cpp
@@ -1007,6 +1007,8 @@ void y8950::write_data(uint8_t data)
 	{
 		case 0x04:  // IRQ control
 			m_fm.write(m_address, data);
+			if ((data & STATUS_ADPCM_B_EOS) != 0)
+				m_adpcm_b.clear_status(adpcm_b_channel::STATUS_EOS);
 			read_status();
 			break;
 

--- a/src/ymfm_opn.cpp
+++ b/src/ymfm_opn.cpp
@@ -1235,7 +1235,10 @@ void ym2608::write_data_hi(uint8_t data)
 	{
 		// 110: IRQ flag control
 		if (bitfield(data, 7))
+		{
 			m_fm.set_reset_status(0, 0xff);
+			m_adpcm_b.clear_status(adpcm_b_channel::STATUS_EOS | adpcm_b_channel::STATUS_PLAYING);
+		}
 		else
 		{
 			m_flag_control = data;
@@ -2022,6 +2025,8 @@ void ym2610::write_data(uint8_t data)
 		// 1C: EOS flag reset
 		m_flag_mask = ~data & EOS_FLAGS_MASK;
 		m_eos_status &= ~(data & EOS_FLAGS_MASK);
+		if (bitfield(data, 7))
+			m_adpcm_b.clear_status(adpcm_b_channel::STATUS_EOS);
 	}
 	else
 	{


### PR DESCRIPTION
@aaronsgiles Thanks for merging https://github.com/aaronsgiles/ymfm/pull/35 .

We have changed the definition of at_end() and at_limit() in https://github.com/aaronsgiles/ymfm/pull/33#issuecomment-1114387840 .

So, we need to modify the address checking not only on clock(), but also on read()/write().
Please check this patch.

P.S.
I have resumed verification of real YM2608's ADPCM.
https://github.com/hyano/opna-analyze/blob/main/doc/OPNA.md
If I can find the internal behavior I will try to implement and send you another PR.

