### PR TITLE
Make OPL4 device identification device-specific

### DIFF
--- a/src/ymfm_opl.cpp
+++ b/src/ymfm_opl.cpp
@@ -1716,7 +1716,8 @@ uint8_t ymf278b::read_status()
 uint8_t ymf278b::read_data_pcm()
 {
 	// read from PCM
-	if (bitfield(m_address, 9) != 0) {
+	if (bitfield(m_address, 9) != 0)
+	{
 		uint8_t result = m_pcm.read(m_address & 0xff);
 		if ((m_address & 0xff) == 0x02)
 			result |= 0x20;

--- a/src/ymfm_opl.cpp
+++ b/src/ymfm_opl.cpp
@@ -1715,9 +1715,14 @@ uint8_t ymf278b::read_status()
 
 uint8_t ymf278b::read_data_pcm()
 {
-	// write to FM
-	if (bitfield(m_address, 9) != 0)
-		return m_pcm.read(m_address & 0xff);
+	// read from PCM
+	if (bitfield(m_address, 9) != 0) {
+		uint8_t result = m_pcm.read(m_address & 0xff);
+		if ((m_address & 0xff) == 0x02)
+			result |= 0x20;
+
+		return result;
+	}
 	return 0;
 }
 

--- a/src/ymfm_pcm.cpp
+++ b/src/ymfm_pcm.cpp
@@ -46,7 +46,6 @@ namespace ymfm
 void pcm_registers::reset()
 {
 	std::fill_n(&m_regdata[0], REGISTERS, 0);
-	m_regdata[0x02] = 0x20;
 	m_regdata[0xf8] = 0x1b;
 }
 


### PR DESCRIPTION
This PR makes YMF278B device identification device-specific instead of being the same across all OPL4 variants.