### PR TITLE
Fix virtual destructor warnings

### DIFF
--- a/src/ymfm.h
+++ b/src/ymfm.h
@@ -483,6 +483,8 @@ public:
 class ymfm_engine_callbacks
 {
 public:
+	virtual ~ymfm_engine_callbacks() = default;
+
 	// timer callback; called by the interface when a timer fires
 	virtual void engine_timer_expired(uint32_t tnum) = 0;
 
@@ -504,6 +506,8 @@ class ymfm_interface
 	template<typename RegisterType> friend class fm_engine_base;
 
 public:
+	virtual ~ymfm_interface() = default;
+
 	// the following functions must be implemented by any derived classes; the
 	// default implementations are sufficient for some minimal operation, but will
 	// likely need to be overridden to integrate with the outside world; they are

--- a/src/ymfm_ssg.h
+++ b/src/ymfm_ssg.h
@@ -49,6 +49,8 @@ namespace ymfm
 class ssg_override
 {
 public:
+	virtual ~ssg_override() = default;
+
 	// reset our status
 	virtual void ssg_reset() = 0;
 


### PR DESCRIPTION
Compiling ymfm on MSVC currently produces the following warning:
```
ymfm\src\ymfm_fm.h(459,1): warning C4265: 'ymfm::fm_engine_base<ymfm::opl_registers>': class has virtual functions, but its non-trivial destructor is not virtual; instances of this class may not be destructed correctly
```
To ensure any classes deriving from ymfm interfaces don't leak, I added virtual destructors to all the base abstract classes.