### PR TITLE
Keyon all ops on CSM mode

### DIFF
--- a/src/ymfm_fm.ipp
+++ b/src/ymfm_fm.ipp
@@ -1515,7 +1515,7 @@ void fm_engine_base<RegisterType>::engine_timer_expired(uint32_t tnum)
 		for (uint32_t chnum = 0; chnum < CHANNELS; chnum++)
 			if (bitfield(RegisterType::CSM_TRIGGER_MASK, chnum))
 			{
-				m_channel[chnum]->keyonoff(1, KEYON_CSM, chnum);
+				m_channel[chnum]->keyonoff(0xf, KEYON_CSM, chnum);
 				m_modified_channels |= 1 << chnum;
 			}
 


### PR DESCRIPTION
When Timer-A expires, all operators should be keyed on, while the current code keys on only operator 1.

Looks like it was once fixed at
39f8389fb2731abac05c71b83c5057405b679543
but later
a78b567bd577200250373eb5847363ffbba4b65c
reverted it.