### PR TITLE
Fix left-shift signed overflows (UB)

### DIFF
--- a/src/ymfm.h
+++ b/src/ymfm.h
@@ -244,7 +244,8 @@ inline int16_t roundtrip_fp(int32_t value)
 
 	// apply the shift back and forth to zero out bits that are lost
 	exponent -= 1;
-	return (value >> exponent) << exponent;
+    int32_t mask = (1 << exponent) - 1;
+	return value & ~mask;
 }
 
 

--- a/src/ymfm_opm.cpp
+++ b/src/ymfm_opm.cpp
@@ -60,17 +60,17 @@ opm_registers::opm_registers() :
 	{
 		// waveform 0 is a sawtooth
 		uint8_t am = index ^ 0xff;
-		int8_t pm = int8_t(index);
+		uint8_t pm = index;
 		m_lfo_waveform[0][index] = am | (pm << 8);
 
 		// waveform 1 is a square wave
 		am = bitfield(index, 7) ? 0 : 0xff;
-		pm = int8_t(am ^ 0x80);
+		pm = am ^ 0x80;
 		m_lfo_waveform[1][index] = am | (pm << 8);
 
 		// waveform 2 is a triangle wave
 		am = bitfield(index, 7) ? (index << 1) : ((index ^ 0xff) << 1);
-		pm = int8_t(bitfield(index, 6) ? am : ~am);
+		pm = bitfield(index, 6) ? am : ~am;
 		m_lfo_waveform[2][index] = am | (pm << 8);
 
 		// waveform 3 is noise; it is filled in dynamically

--- a/src/ymfm_opm.cpp
+++ b/src/ymfm_opm.cpp
@@ -330,7 +330,7 @@ uint32_t opm_registers::compute_phase_step(uint32_t choffs, uint32_t opoffs, opd
 		if (pm_sensitivity < 6)
 			delta += lfo_raw_pm >> (6 - pm_sensitivity);
 		else
-			delta += lfo_raw_pm << (pm_sensitivity - 5);
+			delta += uint32_t(lfo_raw_pm) << (pm_sensitivity - 5);
 	}
 
 	// apply delta and convert to a frequency number

--- a/src/ymfm_opz.cpp
+++ b/src/ymfm_opz.cpp
@@ -129,17 +129,17 @@ opz_registers::opz_registers() :
 	{
 		// waveform 0 is a sawtooth
 		uint8_t am = index ^ 0xff;
-		int8_t pm = int8_t(index);
+		uint8_t pm = index;
 		m_lfo_waveform[0][index] = am | (pm << 8);
 
 		// waveform 1 is a square wave
 		am = bitfield(index, 7) ? 0 : 0xff;
-		pm = int8_t(am ^ 0x80);
+		pm = am ^ 0x80;
 		m_lfo_waveform[1][index] = am | (pm << 8);
 
 		// waveform 2 is a triangle wave
 		am = bitfield(index, 7) ? (index << 1) : ((index ^ 0xff) << 1);
-		pm = int8_t(bitfield(index, 6) ? am : ~am);
+		pm = bitfield(index, 6) ? am : ~am;
 		m_lfo_waveform[2][index] = am | (pm << 8);
 
 		// waveform 3 is noise; it is filled in dynamically


### PR DESCRIPTION
In both cases pm may be negative, and left shifting a negative value is signed overflow (undefined behavior). The destination is 16-bit, and 8-bit pm is always left-shifted by 8, shifting any sign extension of pm beyond the destination. Therefore its signedness plays no practical role in these operations.

These shift operands are first promoted to int, and so it's still signed left-shifts of non-negative operands. 32-and 64-bit host have plenty of overhead. On 16-bit hosts this shifts into the sign bit, and no farther, a well-defined special case in C++ (CWG 1457).

Removing the explicit int8_t casts isn't necessary, but they no longer make sense with this change.

I discovered these via Undefined Behavior Sanitizer on x16emu.