### PR TITLE
fix: YMF289B: OUTPUTS not derived from the engine parameter.

### DIFF
--- a/src/ymfm_opl.h
+++ b/src/ymfm_opl.h
@@ -686,7 +686,7 @@ class ymf289b
 public:
 	using fm_engine = fm_engine_base<opl3_registers>;
 	using output_data = fm_engine::output_data;
-	static constexpr uint32_t OUTPUTS = 2;
+	static constexpr uint32_t OUTPUTS = fm_engine::OUTPUTS;
 
 	// constructor
 	ymf289b(ymfm_interface &intf);


### PR DESCRIPTION
## Summary

For YMF289B, the number of outputs advertised is different from that of fm_engine, unlike the other chips in the same header file.

## Sidenote

I found this during implementing a Python binding of this project. I reall apperciate the works and publishing it as an OSS with a generous license. Take a look at https://github.com/moriyoshi/ymfm-py.git if interested.